### PR TITLE
Swap LAST_ENERGY_CONSUMED and LAST_ENERGY_TRANSFER_LOG_ENTRY to `WATT_HOUR` measurements

### DIFF
--- a/custom_components/fordpass/const_tags.py
+++ b/custom_components/fordpass/const_tags.py
@@ -11,6 +11,7 @@ from homeassistant.components.sensor import SensorStateClass, SensorDeviceClass,
 from homeassistant.const import (
     UnitOfTime,
     UnitOfPower,
+    UnitOfEnergy,
     UnitOfSpeed,
     UnitOfLength,
     UnitOfTemperature,
@@ -720,7 +721,7 @@ SENSORS = [
         key=Tag.LAST_ENERGY_CONSUMED.key,
         icon="mdi:counter",
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfPower.WATT,
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
         has_entity_name=True,
     ),
     ExtSensorEntityDescription(
@@ -729,7 +730,7 @@ SENSORS = [
         skip_existence_check=True,
         icon="mdi:ev-station",
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         has_entity_name=True,
     ),
 


### PR DESCRIPTION
This pull request updates unit definitions for energy-related sensor entities in the `custom_components/fordpass/const_tags.py` file to use the correct units of measurement. Specifically, it changes the units from power (watts) to energy (watt-hours), ensuring more accurate representation of the data for `LAST_ENERGY_CONSUMED` and `LAST_ENERGY_TRANSFER_LOG_ENTRY`

Currently, the values are displayed in HA as "W" or "kW" but the values are actually "Wh" or "kWh"

**Unit definition corrections:**

* Changed the import to include `UnitOfEnergy` instead of only `UnitOfPower` to support energy units.
* Updated `native_unit_of_measurement` for last trip consumed energy (`LAST_ENERGY_CONSUMED`) from `UnitOfPower.WATT` to `UnitOfEnergy.WATT_HOUR`.
* Updated `native_unit_of_measurement` for the last charged energy (`LAST_ENERGY_TRANSFER_LOG_ENTRY`) from `UnitOfPower.KILO_WATT` to `UnitOfEnergy.KILO_WATT_HOUR`.