### PR TITLE
Add Danish, Swedish, and Norwegian translations

### DIFF
--- a/custom_components/fordpass/translations/da.json
+++ b/custom_components/fordpass/translations/da.json
@@ -1,0 +1,424 @@
+{
+    "selector": {
+        "region": {
+            "options": {
+                "aaa": "------ FORD-køretøjer ------",
+                "deu": "Tyskland",
+                "dnk": "Danmark",
+                "fra": "Frankrig",
+                "nld": "Holland",
+                "ita": "Italien",
+                "esp": "Spanien",
+                "nor": "Norge",
+                "pol": "Polen",
+                "prt": "Portugal",
+                "gbr": "Storbritannien og Nordirland",
+                "aus": "Australien [kræver en 'ford.com.au/ford.co.nz'-konto]",
+                "nzl": "New Zealand [kræver en 'ford.co.nz/ford.com.au'-konto]",
+                "zaf": "Sydafrika [kræver en 'ford.co.za'-konto]",
+                "can": "Canada",
+                "mex": "Mexico",
+                "usa": "USA",
+                "bra": "Brasilien [kræver en 'ford.com.br/ford.com.ar'-konto]",
+                "arg": "Argentina [kræver en 'ford.com.ar/ford.com.br'-konto]",
+                "rest_of_europe": "Andre europæiske lande",
+                "rest_of_world": "Resten af verden",
+                "zzz": "------ LINCOLN-køretøjer ------",
+                "lincoln_usa": "USA"
+            }
+        },
+        "setup_type": {
+            "options": {
+                "new_account": "Tilføj en ny FordPass™/The Lincoln Way™-konto eller konfigurér en ny region",
+                "add_vehicle": "Tilføj et køretøj fra en eksisterende FordPass™/The Lincoln Way™-konto/region"
+            }
+        },
+        "brand": {
+            "options": {
+                "ford": "Ford-køretøjer – FordPass™-app",
+                "lincoln": "Lincoln-køretøjer – The Lincoln Way™-app"
+            }
+        },
+        "precondition_temperature": {
+            "options": {
+                "low": "Køl",
+                "medium": "Mellem",
+                "high": "Varm",
+                "off": "Slukket"
+            }
+        },
+        "schedule_days": {
+            "options": {
+                "monday": "01 Mandag",
+                "tuesday": "02 Tirsdag",
+                "wednesday": "03 Onsdag",
+                "thursday": "04 Torsdag",
+                "friday": "05 Fredag",
+                "saturday": "06 Lørdag",
+                "sunday": "07 Søndag"
+            }
+        }
+    },
+    "config": {
+        "abort": {
+            "already_configured": "Kontoen er allerede tilføjet",
+            "no_vehicles": "Der er ingen køretøjer på kontoen, eller alle er allerede tilføjet",
+            "reauth_successful": "Genautorisering blev gennemført",
+            "reconfigure_successful": "Omkonfigurationen blev gennemført",
+            "reauth_reload_failed": "Genautorisering blev gennemført\n\nMen integrationen kunne ikke genindlæses. Genstart Home Assistant for at færdiggøre genautoriseringen, eller tjek dit log for flere detaljer",
+            "reauth_unsuccessful": "Genautorisering MISLYKKEDES\n\nTjek dit token og prøv igen",
+            "reauth_not_possible": "Der blev ikke fundet en gyldig region\n\nDu er desværre nødt til at konfigurere integrationen forfra",
+            "no_filesystem_access": "Denne integration har brug for adgang til Home Assistants lokale filsystem for at kunne gemme en nøgle til din FordPass™/The Lincoln Way™-konto.\n\nDer skal oprettes en undermappe i mappen '.storage/'. Det er ikke muligt lige nu – en intern test slog fejl. Du kan finde detaljer i din Home Assistant-log.\n\nKontrollér, at din Home Assistant-installation kører som en bruger, der har skriverettigheder til det lokale filsystem.\n\nKører du Home Assistant i en Docker-container, så sørg for, at containeren kører som den rigtige bruger og har adgang til filsystemet.\n\nTjek din installation, og start opsætningen af integrationen igen, når adgangen til filsystemet er på plads.",
+            "no_brand": "Der kunne ikke registreres et bilmærke (Ford eller Lincoln)",
+            "oauth_error_final": "## Hentning af det endelige OAuth-token mislykkedes\nNoget gik galt under hentningen af det endelige adgangstoken fra Ford. Er du sikker på, at de oplysninger, du har angivet som `client-id` og `secret`, er korrekte?\nTjek også Home Assistant-loggen for yderligere fejlmeddelelser, der kan hjælpe dig med at finde årsagen.\n\n#### Mulig årsag:\n{error_info}"
+        },
+        "error": {
+            "cannot_connect": "Kunne ikke oprette forbindelse",
+            "invalid_auth": "Ugyldige loginoplysninger",
+            "invalid_vin": "Stelnummeret (VIN) blev ikke fundet på kontoen",
+            "invalid_mobile": "Hvis du bruger den sydafrikanske region, skal mobilnummeret angives som brugernavn",
+            "invalid_token": "Tokenet er ugyldigt. Tjek, at du har kopieret det rigtige token fra Header-Location – det skal starte med fordapp:// (eller lincolnapp://)",
+            "unknown": "Uventet fejl"
+        },
+        "step": {
+            "user": {
+                "title": "Tilføj ny FordPass™/The Lincoln Way™-konto eller et nyt køretøj",
+                "description": "Du har allerede konfigureret mindst én FordPass™/The Lincoln Way™-konto, så du skal først vælge, om du vil tilføje endnu et køretøj eller en ny konto (eller region).\n-- --\n### Vigtigt om understøttelse af flere køretøjer\n\nHvis du har __flere__ køretøjer registreret på din FordPass™/The Lincoln Way™-konto, skal du i selve FordPass™/The Lincoln Way™-app'en først vælge det køretøj, du vil bruge, før du kan se data eller styre funktioner. __Den samme begrænsning__ gælder for denne Home Assistant-integration.\n\nÅrsagen er, at FordPass™-app'en og denne integration bruger en websocket-forbindelse til Fords backend, og den er bundet til ét køretøj ad gangen.\n\nFlere detaljer her: {repo}?tab=readme-ov-file#multi-vehicle-support",
+                "data": {
+                    "setup_type": "Hvad vil du gerne?"
+                },
+                "data_description": {
+                    "setup_type": "Hvis du opretter et andet køretøj med den samme konto, må kun det ene være aktivt i HA ad gangen – ellers overskriver de hinandens adgangstokens"
+                }
+            },
+            "user_connect": {
+                "title": "Tilføj et nyt Ford-køretøj",
+                "description": "## Velkommen til FordConnect Query-integrationen\nDette er et alternativ til [FordPass-integrationen]({repo}) og bruger FordConnect Query-API'et. Det API giver __kun læseadgang__ til dine køretøjsdata.\n### Krav\n- Bilen skal have det nyeste indbyggede modem og være registreret/godkendt i FordPass™-app'en\n- Et API-legitimationsoplysningspar, som tidligere er registreret hos Fords udviklerportal i EU/UK/NA.\n\nDu kan læse mere i [_Application Registration Guide_, som indeholder en trin-for-trin-vejledning]({repo}/blob/main/docs/REGISTER_APPLICATION.md) til at registrere et program i Fords EU-udviklerportal.\n### Brug for mere hjælp?\nResten af opsætningen er beskrevet i [Integration Setup Guide]({repo}/blob/main/docs/CONFIGURE_INTEGRATION.md)\n### En lille slutbemærkning\nHvis du synes, denne integration er nyttig, så overvej at støtte mig som GitHub-projektsponsor (eller på en af de andre måder, der er beskrevet [her i min profil@GitHub]({github})) – stor tak til dem, der allerede gør det – I er fantastiske!",
+                "data": {
+                    "config_title": "Vælg et navn til konfigurationen"
+                }
+            },
+            "select_account": {
+                "title": "Vælg din FordPass™/The Lincoln Way™-konto",
+                "description": "Vælg den FordPass™/The Lincoln Way™-konto, du vil tilføje endnu et køretøj fra.",
+                "data": {
+                    "account": "FordPass™/The Lincoln Way™-konto"
+                },
+                "data_description": {
+                    "account": "Hvis du opretter et andet køretøj med den samme konto, må kun det ene være aktivt i HA ad gangen – ellers overskriver de hinandens adgangstokens"
+                }
+            },
+            "token": {
+                "title": "Opsætning af token",
+                "description": "Opsætningen af token kræver, at du åbner et ekstra browservindue (med udviklerværktøjer aktiveret – F12) for at fange det endelige adgangstoken.\r\rDet er en lidt usædvanlig fremgangsmåde for en Home Assistant-integration. Du kan læse detaljerne i [opsætningsvejledningen]({repo}/blob/main/doc/OBTAINING_TOKEN.md)\r\rFølg disse trin:\r1. Kopiér linket nedenfor, eller klik på det følgende link (skal åbnes i en ny fane/vindue): [Start autoriseringsprocessen]({url})\r2. Åbn en browser (med udviklerværktøjer aktiveret), og indsæt linket i den anden browser\r3. Indtast dine FordPass™/The Lincoln Way™-loginoplysninger igen, og tryk på login-knappen\r4. Hold øje med fanen Network, indtil du ser anmodningen `?code=`\r5. Kopiér hele `Request-URL` fra anmodningen i browserens udviklerværktøjer, og indsæt det i token-feltet nedenfor\r6. Klik OK for at fortsætte",
+                "data": {
+                    "url": "URL: kopiér denne ind i din browser",
+                    "tokenstr": "Token Request-URL: indsæt hele `Request-URL`, når login er gennemført i browseren"
+                }
+            },
+            "reauth_confirm": {
+                "title": "Genautorisering kræves",
+                "description": "Dit tidligere token er ugyldigt – så du skal lave et nyt til kontoen {username}:\r\rDetaljer findes i [opsætningsvejledningen]({repo}/blob/main/doc/OBTAINING_TOKEN.md)\r\rFølg disse trin:\r1. Kopiér linket nedenfor, eller klik på det følgende link (skal åbnes i en ny fane/vindue): [Start autoriseringsprocessen]({url})\r2. Åbn en browser (med udviklerværktøjer aktiveret), og indsæt linket i den anden browser\r3. Indtast dine FordPass™/The Lincoln Way™-loginoplysninger igen, og tryk på login-knappen (lad dig ikke narre af, at spinneren bliver ved med at snurre – det er 'normalt')\r4. Hold øje med fanen Network, indtil du ser anmodningen `?code=`\r5. Kopiér hele `Request-URL` fra anmodningen i browserens udviklerværktøjer, og indsæt det i token-feltet nedenfor\r6. Klik OK for at fortsætte",
+                "data": {
+                    "url": "URL: kopiér denne ind i din browser",
+                    "tokenstr": "Token Request-URL: indsæt hele `Request-URL`, når login er gennemført i browseren"
+                }
+            },
+            "reauth_confirm_connect": {
+                "title": "Genautorisering kræves",
+                "description": "Dit tidligere token er ugyldigt – så du skal lave et nyt til kontoen {username}"
+            },
+            "brand": {
+                "data": {
+                    "brand": "Vælg dit bilmærke"
+                }
+            },
+            "new_account_ford": {
+                "data": {
+                    "password": "FordPass™-adgangskode",
+                    "username": "FordPass™-brugernavn (e-mail)",
+                    "region": "FordPass™-region"
+                },
+                "data_description": {
+                    "username": "Hvis du bruger mobilnummer i stedet for e-mail, så indtast nummeret (uden det indledende 0) og medtag + samt landekoden (f.eks. +99123456789)",
+                    "region": "Den region, du vælger, skal stemme overens med den, du har registreret din FordPass™-konto i. Flere detaljer findes på GitHub"
+                }
+            },
+            "new_account_lincoln": {
+                "data": {
+                    "password": "The Lincoln Way™-adgangskode",
+                    "username": "The Lincoln Way™-brugernavn (e-mail)",
+                    "region": "The Lincoln Way™-region"
+                },
+                "data_description": {
+                    "username": "Hvis du bruger mobilnummer i stedet for e-mail, så indtast nummeret (uden det indledende 0) og medtag + samt landekoden (f.eks. +99123456789)",
+                    "region": "Den region, du vælger, skal stemme overens med den, du har registreret din The Lincoln Way™-konto i. Flere detaljer findes på GitHub"
+                }
+            },
+            "vehicle": {
+                "title": "Vælg et køretøj at tilføje",
+                "description": "Kun køretøjer, som ikke allerede er tilføjet, vises",
+                "data": {
+                    "vin": "Stelnummer (VIN)"
+                }
+            },
+            "vin": {
+                "title": "Indtast stelnummer (VIN) manuelt",
+                "description": "Indtast dit stelnummer (VIN) manuelt – der kunne ikke findes nogen køretøjer automatisk.",
+                "data": {
+                    "vin": "Stelnummer (VIN) for køretøjet"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "pressure_unit": "Trykenhed",
+                    "update_interval": "Forespørgselsinterval mod Ford-API (sekunder)",
+                    "scan_interval": "Forespørgselsinterval mod Ford-API (sekunder)",
+                    "force_remote_climate_control": "Vis altid mulighederne for fjernklima (❄|☀)",
+                    "log_to_filesystem": "Skriv API-svar til HA's lokale filsystem"
+                },
+                "data_description": {
+                    "update_interval": "Mindste interval er 30 sekunder",
+                    "scan_interval": "Mindste interval er 30 sekunder",
+                    "force_remote_climate_control": "Hvis du slår denne til, ignoreres den indstilling, Ford har angivet.",
+                    "log_to_filesystem": "Lad ikke denne indstilling være slået til i længere tid!\rFilerne ligger her: './storage/{integration_name}/data_dumps'"
+                },
+                "description": "Indstillinger for integrationen"
+            }
+        }
+    },
+    "services": {
+        "refresh_status": {
+            "name": "Opdatér køretøjsstatus",
+            "description": "Beder bilen om de nyeste data (det kan tage op til 5 min., før status er opdateret).",
+            "fields": {
+                "vin": {
+                    "name": "Stelnummer (VIN)",
+                    "description": "Indtast et stelnummer for kun at opdatere det pågældende køretøj (uden angivelse opdateres alle tilføjede køretøjer)"
+                }
+            }
+        },
+        "clear_tokens": {
+            "name": "Ryd token-cache",
+            "description": "Rydder de gemte tokens (kræver, at du genautoriserer bagefter)"
+        },
+        "reload": {
+            "name": "Genindlæs",
+            "description": "Genindlæser FordPass-integrationen"
+        },
+        "poll_api": {
+            "name": "Forespørg API",
+            "description": "Forespørger API'et manuelt for nye data (Bemærk: hvis du gør det for ofte, kan du blive midlertidigt blokeret)"
+        },
+        "delete_message": {
+            "name": "Slet FordPass-besked",
+            "description": "Sletter en besked fra besked-listen. Indtast en besked-ID for at slette en bestemt besked.",
+            "fields": {
+                "msgid": {
+                    "name": "Besked-ID",
+                    "description": "Indtast en gyldig besked-ID for at slette en bestemt besked"
+                }
+            }
+        },
+        "update_departure_schedule": {
+            "name": "Opdatér afgangsplan",
+            "description": "Indstil et afgangstidspunkt og en forklimatiserings-temperatur for udvalgte ugedage.",
+            "fields": {
+                "hour": {
+                    "name": "Time",
+                    "description": "Afgangstime (0-23)"
+                },
+                "minute": {
+                    "name": "Minut",
+                    "description": "Afgangsminut – i intervaller af 5 min. (0-55)"
+                },
+                "precondition_temperature": {
+                    "name": "Forklimatiserings-temperatur"
+                },
+                "schedule_days": {
+                    "name": "Dage",
+                    "description": "Vælg én eller flere ugedage"
+                }
+            }
+        },
+        "delete_departure_schedule_by_days": {
+            "name": "Slet afgangsplaner efter dage",
+            "description": "Sletter den første afgangsplan på de valgte ugedage.",
+            "fields": {
+                "schedule_days": {
+                    "name": "Dage",
+                    "description": "Vælg én eller flere ugedage"
+                }
+            }
+        },
+        "delete_departure_schedule_by_ids": {
+            "name": "Slet afgangsplaner efter ID",
+            "description": "Sletter afgangsplaner ud fra deres scheduleID. (se attributten 'schedule' på sensoren 'Næste planlagte afgang')",
+            "fields": {
+                "schedule_ids": {
+                    "name": "Schedule-ID'er",
+                    "description": "Angiv én eller flere scheduleID'er som liste (f.eks. [1,2,3]) eller komma-adskilt streng (f.eks. 1,2,3)"
+                }
+            }
+        }
+    },
+    "entity": {
+        "button": {
+            "update_data":          {"name": "Lokal synkronisering"},
+            "request_refresh":      {"name": "Fjern-synkronisering"},
+            "doorlock":             {"name": "Lås"},
+            "doorunlock":           {"name": "Lås op"},
+            "evstart":              {"name": "Start EV-opladning"},
+            "evcancel":             {"name": "Genoptag EV-opladning"},
+            "evpause":              {"name": "Pause EV-opladning"},
+            "hafshort":             {"name": "Horn & blink [1 sek.]"},
+            "hafdefault":           {"name": "Horn & blink [3 sek.]"},
+            "haflong":              {"name": "Horn & blink [5 sek.]"},
+            "extendremotestart":    {"name": "RC (❄|☀): Forlæng tid"},
+            "msgdeleteall":         {"name": "Beskeder: Slet alle"},
+            "msgdeletelast":        {"name": "Beskeder: Slet seneste"},
+            "trailerlightcheckon":  {"name": "Test af anhængerlys: TIL"},
+            "trailerlightcheckoff": {"name": "Test af anhængerlys: FRA"}
+        },
+        "device_tracker":   {"tracker": {"name": "Køretøjs-tracker"}},
+        "lock":             {"doorlock":{"name": "Døre"}},
+        "switch": {
+            "ignition":                 {"name": "RC (❄|☀): Start [Fjernkontrol]"},
+            "elvehcharge":              {"name": "EV-opladning (pause)"},
+            "guardmode":                {"name": "Vagttilstand"},
+            "autosoftwareupdates":      {"name": "Automatiske softwareopdateringer"},
+            "rccdefrostrear":           {"name": "RC (❄|☀): Bagrudevarme [Fjernkontrol]"},
+            "rccdefrostfront":          {"name": "RC (❄|☀): Forrudevarme [Fjernkontrol]"},
+            "rccsteeringwheel":         {"name": "RC (❄|☀): Rattevarme [Fjernkontrol]"},
+            "departuretimes":           {"name": "Afgangstider"}
+        },
+        "number": {
+            "rcctemperature":       {"name": "RC (❄|☀): Klimatemperatur [Fjernkontrol]"},
+            "elvehtargetcharge":    {"name": "Mål-ladestand"},
+            "globaltargetsoc":      {"name": "Generel: Mål-ladestand"},
+            "globalaccurrentlimit": {"name": "Strømgrænse (AC)"},
+            "globaldcpowerlimit":   {"name": "Effektgrænse (DC)"}
+        },
+        "sensor": {
+            "odometer":                 {"name": "Kilometerstand"},
+            "fuel":                     {"name": "Brændstof"},
+            "battery":                  {"name": "Batteri (12V)"},
+            "oil":                      {"name": "Olielevetid"},
+            "tirepressure":             {"name": "Dæktryk"},
+            "gps":                      {"name": "GPS JSON"},
+            "alarm":                    {"name": "Alarmstatus"},
+            "ignitionstatus":           {"name": "Status: tænding"},
+            "doorstatus":               {"name": "Status: døre"},
+            "windowposition":           {"name": "Vinduesstatus"},
+            "lastrefresh":              {"name": "Sidst opdateret"},
+            "elveh":                    {"name": "EV"},
+            "elvehplug":                {"name": "Ladestik"},
+            "elvehcharging":            {"name": "EV-ladestatus"},
+            "elvehchargingpower":       {"name": "EV-ladeeffekt"},
+            "speed":                    {"name": "Hastighed"},
+            "enginespeed":              {"name": "Omdrejningstal"},
+            "gearleverposition":        {"name": "Gearvælger-position"},
+            "indicators":               {"name": "Advarselslamper"},
+            "coolanttemp":              {"name": "Temperatur: kølevæske"},
+            "outsidetemp":              {"name": "Temperatur: udenfor"},
+            "engineoiltemp":            {"name": "Temperatur: motorolie"},
+            "deepsleep":                {"name": "Dvaletilstand"},
+            "firmwareupginprogress":    {"name": "Firmware-opdatering i gang"},
+            "remotestartstatus":        {"name": "RC (❄|☀): Status fjernstart"},
+            "zonelighting":             {"name": "Zonebelysning"},
+            "messages":                 {"name": "Beskeder"},
+            "dieselsystemstatus":       {"name": "Status: dieselsystem"},
+            "exhaustfluidlevel":        {"name": "AdBlue-niveau"},
+            "events":                   {"name": "Hændelser"},
+            "metrics":                  {"name": "Målinger"},
+            "states":                   {"name": "Tilstande"},
+            "vehicles":                 {"name": "Køretøjer"},
+
+            "soc":                      {"name": "Batteriniveau (EV)"},
+            "evccstatus":               {"name": "EVCC-statuskode"},
+            "seatbelt":                 {"name": "Sikkerhedsselestatus"},
+            "deviceconnectivity":       {"name": "Forbindelse"},
+
+            "yawrate":                  {"name": "Girationsrate"},
+            "acceleration":             {"name": "Acceleration"},
+            "brakepedalstatus":         {"name": "Status: bremsepedal"},
+            "braketorque":              {"name": "Bremsemoment"},
+            "acceleratorpedalposition": {"name": "Speeder-position"},
+            "parkingbrakestatus":       {"name": "Status: håndbremse"},
+            "torqueattransmission":     {"name": "Drejningsmoment ved gearkasse"},
+            "wheeltorquestatus":        {"name": "Status: hjulmoment"},
+            "cabintemperature":         {"name": "Kabinetemperatur"},
+            "lastenergyconsumed":       {"name": "EV-energiforbrug (sidste tur)"},
+            "energytransferlogentry":   {"name": "EV-seneste opladning"},
+            "remotestartcountdown":     {"name": "RC (❄|☀): Resterende tid"},
+            "doorlock":                 {"name": "Status: låse"},
+
+            "departureschedules":       {"name": "Næste planlagte afgang"}
+        },
+        "select": {
+            "zonelighting": {
+                "name": "Zonebelysning",
+                "state": {
+                    "0": "TIL",
+                    "1": "Foran",
+                    "2": "Bagved",
+                    "3": "Førerside",
+                    "4": "Passagerside",
+                    "off": "FRA"
+                }
+            },
+            "rcctemperature": {
+              "name": "RC (❄|☀): Temperatur [Fjernkontrol]",
+              "state": {"lo": "LAV",
+                        "16": "16,0°C", "16_5": "16,5°C", "17": "17,0°C", "17_5": "17,5°C", "18": "18,0°C", "18_5": "18,5°C", "19": "19,0°C", "19_5": "19,5°C", "20": "20,0°C", "20_5": "20,5°C",
+                        "21": "21,0°C", "21_5": "21,5°C", "22": "22,0°C", "22_5": "22,5°C", "23": "23,0°C", "23_5": "23,5°C", "24": "24,0°C", "24_5": "24,5°C", "25": "25,0°C", "25_5": "25,5°C",
+                        "26": "26,0°C", "26_5": "26,5°C", "27": "27,0°C", "27_5": "27,5°C", "28": "28,0°C", "28_5": "28,5°C", "29": "29,0°C", "29_5": "29,5°C", "30": "30,0°C",
+                        "hi": "HØJ"}
+            },
+            "rcctemperaturefahrenheit": {
+                "name": "RC (❄|☀): Temperatur [Fjernkontrol]",
+                "state": {"lo": "LAV",
+                          "16": "60.8°F", "16_5": "61.7°F", "17": "62.6°F", "17_5": "63.5°F", "18": "64.4°F", "18_5": "65.3°F", "19": "66.2°F", "19_5": "67.1°F", "20": "68.0°F", "20_5": "68.9°F",
+                          "21": "69.8°F", "21_5": "70.7°F", "22": "71.6°F", "22_5": "72.5°F", "23": "73.4°F", "23_5": "74.3°F", "24": "75.2°F", "24_5": "76.1°F", "25": "77.0°F", "25_5": "77.9°F",
+                          "26": "78.8°F", "26_5": "79.7°F", "27": "80.6°F", "27_5": "81.5°F", "28": "82.4°F", "28_5": "83.3°F", "29": "84.2°F", "29_5": "85.1°F", "30": "86.0°F",
+                          "hi": "HØJ"}
+            },
+            "rccseatrearleft": {
+                "name": "RC (❄|☀): Sæde bag venstre [Fjernkontrol]",
+                "state": { "off": "Slukket", "cooled1": "Køling I", "cooled2": "Køling II", "cooled3": "Køling III", "heated1": "Varme I", "heated2": "Varme II", "heated3": "Varme III"}
+            },
+            "rccseatrearright": {
+                "name": "RC (❄|☀): Sæde bag højre [Fjernkontrol]",
+                "state": { "off": "Slukket", "cooled1": "Køling I", "cooled2": "Køling II", "cooled3": "Køling III", "heated1": "Varme I", "heated2": "Varme II", "heated3": "Varme III"}
+            },
+            "rccseatfrontleft": {
+                "name": "RC (❄|☀): Sæde foran venstre [Fjernkontrol]",
+                "state": { "off": "Slukket", "cooled1": "Køling I", "cooled2": "Køling II", "cooled3": "Køling III", "heated1": "Varme I", "heated2": "Varme II", "heated3": "Varme III"}
+            },
+            "rccseatfrontright": {
+                "name": "RC (❄|☀): Sæde foran højre [Fjernkontrol]",
+                "state": { "off": "Slukket", "cooled1": "Køling I", "cooled2": "Køling II", "cooled3": "Køling III", "heated1": "Varme I", "heated2": "Varme II", "heated3": "Varme III"}
+            },
+            "elvehtargetcharge": {
+                "name": "Mål-ladestand",
+                "state": { "50": "50%", "60": "60%", "70": "70%", "80": "80%", "85": "85%", "90": "90%", "95": "95%", "100": "100%"}
+            },
+            "elvehtargetchargealt1": {
+                "name": "Mål-ladestand [alternativ placering 1]",
+                "state": { "50": "50%", "60": "60%", "70": "70%", "80": "80%", "85": "85%", "90": "90%", "95": "95%", "100": "100%"}
+            },
+            "elvehtargetchargealt2": {
+                "name": "Mål-ladestand [alternativ placering 2]",
+                "state": { "50": "50%", "60": "60%", "70": "70%", "80": "80%", "85": "85%", "90": "90%", "95": "95%", "100": "100%"}
+            },
+            "globaltargetsoc": {
+                "name": "Generel: Mål-ladestand",
+                "state": { "50": "50%", "60": "60%", "70": "70%", "80": "80%", "85": "85%", "90": "90%", "95": "95%", "100": "100%"}
+            }
+        }
+    }
+}

--- a/custom_components/fordpass/translations/no.json
+++ b/custom_components/fordpass/translations/no.json
@@ -1,0 +1,424 @@
+{
+    "selector": {
+        "region": {
+            "options": {
+                "aaa": "------ FORD-kjøretøy ------",
+                "deu": "Tyskland",
+                "dnk": "Danmark",
+                "fra": "Frankrike",
+                "nld": "Nederland",
+                "ita": "Italia",
+                "esp": "Spania",
+                "nor": "Norge",
+                "pol": "Polen",
+                "prt": "Portugal",
+                "gbr": "Storbritannia og Nord-Irland",
+                "aus": "Australia [krever en 'ford.com.au/ford.co.nz'-konto]",
+                "nzl": "New Zealand [krever en 'ford.co.nz/ford.com.au'-konto]",
+                "zaf": "Sør-Afrika [krever en 'ford.co.za'-konto]",
+                "can": "Canada",
+                "mex": "Mexico",
+                "usa": "USA",
+                "bra": "Brasil [krever en 'ford.com.br/ford.com.ar'-konto]",
+                "arg": "Argentina [krever en 'ford.com.ar/ford.com.br'-konto]",
+                "rest_of_europe": "Andre europeiske land",
+                "rest_of_world": "Resten av verden",
+                "zzz": "------ LINCOLN-kjøretøy ------",
+                "lincoln_usa": "USA"
+            }
+        },
+        "setup_type": {
+            "options": {
+                "new_account": "Legg til en ny FordPass™/The Lincoln Way™-konto eller konfigurer en ny region",
+                "add_vehicle": "Legg til et kjøretøy fra en eksisterende FordPass™/The Lincoln Way™-konto/region"
+            }
+        },
+        "brand": {
+            "options": {
+                "ford": "Ford-kjøretøy – FordPass™-app",
+                "lincoln": "Lincoln-kjøretøy – The Lincoln Way™-app"
+            }
+        },
+        "precondition_temperature": {
+            "options": {
+                "low": "Sval",
+                "medium": "Middels",
+                "high": "Varm",
+                "off": "Av"
+            }
+        },
+        "schedule_days": {
+            "options": {
+                "monday": "01 Mandag",
+                "tuesday": "02 Tirsdag",
+                "wednesday": "03 Onsdag",
+                "thursday": "04 Torsdag",
+                "friday": "05 Fredag",
+                "saturday": "06 Lørdag",
+                "sunday": "07 Søndag"
+            }
+        }
+    },
+    "config": {
+        "abort": {
+            "already_configured": "Kontoen er allerede konfigurert",
+            "no_vehicles": "Det finnes ingen kjøretøy på kontoen, eller alle er allerede lagt til",
+            "reauth_successful": "Re-autentiseringen ble fullført",
+            "reconfigure_successful": "Omkonfigurasjonen var vellykket",
+            "reauth_reload_failed": "Re-autentiseringen ble fullført\n\nMen integrasjonen kunne ikke lastes inn på nytt. Start Home Assistant på nytt for å fullføre re-autentiseringen, eller sjekk loggen for flere detaljer",
+            "reauth_unsuccessful": "Re-autentiseringen MISLYKTES\n\nSjekk tokenet og prøv igjen",
+            "reauth_not_possible": "Ingen gyldig region funnet\n\nDu må dessverre konfigurere integrasjonen på nytt",
+            "no_filesystem_access": "Denne integrasjonen trenger tilgang til det lokale filsystemet i Home Assistant-installasjonen din for å kunne lagre en nøkkel til FordPass™/The Lincoln Way™-kontoen din.\n\nFor dette opprettes en undermappe i mappen '.storage/'. Det er ikke mulig akkurat nå – en intern test feilet. Du finner detaljer i Home Assistant-loggen din.\n\nKontroller at Home Assistant-installasjonen kjøres som riktig bruker med skrivetilgang til det lokale filsystemet.\n\nKjører du Home Assistant i en Docker-container, sørg for at containeren kjøres med riktig bruker og har tilgang til filsystemet.\n\nSjekk installasjonen og start oppsettet av integrasjonen på nytt når tilgangen til filsystemet er på plass.",
+            "no_brand": "Ingen bilmerke (Ford eller Lincoln) ble registrert",
+            "oauth_error_final": "## Henting av det endelige OAuth-tokenet mislyktes\nNoe gikk galt under henting av det endelige tilgangstokenet fra Ford. Er du sikker på at opplysningene du har angitt som `client-id` og `secret` er riktige?\nSjekk også loggen i Home Assistant for flere feilmeldinger som kan hjelpe deg med å finne årsaken.\n\n#### Mulig årsak:\n{error_info}"
+        },
+        "error": {
+            "cannot_connect": "Kunne ikke koble til",
+            "invalid_auth": "Ugyldige innloggingsdetaljer",
+            "invalid_vin": "VIN-nummeret ble ikke funnet på kontoen",
+            "invalid_mobile": "Hvis du bruker den sør-afrikanske regionen, må mobilnummeret oppgis som brukernavn",
+            "invalid_token": "Tokenet er ugyldig. Kontroller at du har kopiert riktig token fra Header-Location – det skal starte med fordapp:// (eller lincolnapp://)",
+            "unknown": "Uventet feil"
+        },
+        "step": {
+            "user": {
+                "title": "Legg til ny FordPass™/The Lincoln Way™-konto eller kjøretøy",
+                "description": "Du har allerede konfigurert minst én FordPass™/The Lincoln Way™-konto, så du må først velge om du vil legge til enda et kjøretøy eller en ny konto (eller region).\n-- --\n### Viktig informasjon om støtte for flere kjøretøy\n\nHvis du har __flere__ kjøretøy registrert på FordPass™/The Lincoln Way™-kontoen din, må du i selve FordPass™/The Lincoln Way™-appen først velge det kjøretøyet du vil bruke før du kan se data eller styre funksjoner. __Den samme begrensningen__ gjelder for denne Home Assistant-integrasjonen.\n\nÅrsaken er at FordPass™-appen og denne integrasjonen bruker en websocket-tilkobling til Fords backend, som er bundet til ett kjøretøy om gangen.\n\nFlere detaljer her: {repo}?tab=readme-ov-file#multi-vehicle-support",
+                "data": {
+                    "setup_type": "Hva vil du gjøre?"
+                },
+                "data_description": {
+                    "setup_type": "Hvis du legger til et nytt kjøretøy med samme konto, kan bare ett av dem være aktivt i HA om gangen – ellers overskriver de hverandres tilgangstokens"
+                }
+            },
+            "user_connect": {
+                "title": "Legg til et nytt Ford-kjøretøy",
+                "description": "## Velkommen til FordConnect Query-integrasjonen\nDette er et alternativ til [FordPass-integrasjonen]({repo}) og bruker FordConnect Query-API-et. Dette API-et gir __kun lesetilgang__ til kjøretøysdataene dine.\n### Krav\n- Bilen må ha det nyeste innebygde modemet og være registrert/godkjent i FordPass™-appen\n- Et API-legitimasjonspar som tidligere er registrert hos Fords utviklerportal i EU/UK/NA.\n\nMer informasjon finner du i [_Application Registration Guide_, som inneholder en trinn-for-trinn-veiledning]({repo}/blob/main/docs/REGISTER_APPLICATION.md) for å registrere et program i Fords EU-utviklerportal.\n### Trenger du mer hjelp?\nResten av oppsettet er beskrevet i [Integration Setup Guide]({repo}/blob/main/docs/CONFIGURE_INTEGRATION.md)\n### En liten avsluttende kommentar\nHvis du synes denne integrasjonen er nyttig, vurder å støtte meg som GitHub-prosjektsponsor (eller på en av de andre måtene som er beskrevet [her i profilen min@GitHub]({github})) – stor takk til dere som allerede gjør det – dere er fantastiske!",
+                "data": {
+                    "config_title": "Velg et navn for konfigurasjonen"
+                }
+            },
+            "select_account": {
+                "title": "Velg din FordPass™/The Lincoln Way™-konto",
+                "description": "Velg den FordPass™/The Lincoln Way™-kontoen du vil legge til enda et kjøretøy fra.",
+                "data": {
+                    "account": "FordPass™/The Lincoln Way™-konto"
+                },
+                "data_description": {
+                    "account": "Hvis du legger til et nytt kjøretøy med samme konto, kan bare ett av dem være aktivt i HA om gangen – ellers overskriver de hverandres tilgangstokens"
+                }
+            },
+            "token": {
+                "title": "Oppsett av token",
+                "description": "Oppsett av token krever at du åpner et ekstra nettleservindu (med utviklerverktøy aktivert – F12) for å fange det endelige tilgangstokenet.\r\rDette er en uvanlig fremgangsmåte for en Home Assistant-integrasjon. Du finner detaljer i [oppsettsveiledningen]({repo}/blob/main/doc/OBTAINING_TOKEN.md)\r\rFølg disse trinnene:\r1. Kopier lenken nedenfor, eller klikk på følgende lenke (må åpnes i en ny fane/vindu): [Start autorisasjonsprosessen]({url})\r2. Åpne en nettleser (med utviklerverktøy aktivert) og lim inn lenken i den andre nettleseren\r3. Skriv inn FordPass™/The Lincoln Way™-innloggingsdetaljene dine på nytt, og trykk på påloggingsknappen\r4. Hold øye med Network-fanen til du ser forespørselen `?code=`\r5. Kopier hele `Request-URL` fra forespørselen i nettleserens utviklerverktøy, og lim det inn i token-feltet nedenfor\r6. Klikk OK for å fortsette",
+                "data": {
+                    "url": "URL: kopier denne inn i nettleseren din",
+                    "tokenstr": "Token Request-URL: lim inn hele `Request-URL` når innloggingen er fullført i nettleseren"
+                }
+            },
+            "reauth_confirm": {
+                "title": "Re-autentisering kreves",
+                "description": "Det forrige tokenet ditt er ugyldig – så du må lage et nytt for kontoen {username}:\r\rDetaljer finner du i [oppsettsveiledningen]({repo}/blob/main/doc/OBTAINING_TOKEN.md)\r\rFølg disse trinnene:\r1. Kopier lenken nedenfor, eller klikk på følgende lenke (må åpnes i en ny fane/vindu): [Start autorisasjonsprosessen]({url})\r2. Åpne en nettleser (med utviklerverktøy aktivert) og lim inn lenken i den andre nettleseren\r3. Skriv inn FordPass™/The Lincoln Way™-innloggingsdetaljene dine på nytt, og trykk på påloggingsknappen (la deg ikke lure av at spinneren fortsetter å snurre – det er 'normalt')\r4. Hold øye med Network-fanen til du ser forespørselen `?code=`\r5. Kopier hele `Request-URL` fra forespørselen i nettleserens utviklerverktøy, og lim det inn i token-feltet nedenfor\r6. Klikk OK for å fortsette",
+                "data": {
+                    "url": "URL: kopier denne inn i nettleseren din",
+                    "tokenstr": "Token Request-URL: lim inn hele `Request-URL` når innloggingen er fullført i nettleseren"
+                }
+            },
+            "reauth_confirm_connect": {
+                "title": "Re-autentisering kreves",
+                "description": "Det forrige tokenet ditt er ugyldig – så du må lage et nytt for kontoen {username}"
+            },
+            "brand": {
+                "data": {
+                    "brand": "Velg bilmerke"
+                }
+            },
+            "new_account_ford": {
+                "data": {
+                    "password": "FordPass™-passord",
+                    "username": "FordPass™-brukernavn (e-post)",
+                    "region": "FordPass™-region"
+                },
+                "data_description": {
+                    "username": "Hvis du bruker mobilnummer i stedet for e-post, oppgi nummeret (uten innledende 0) og inkluder + samt landskode (f.eks. +99123456789)",
+                    "region": "Regionen du velger må stemme overens med regionen du har registrert FordPass™-kontoen din i. Flere detaljer finner du på GitHub"
+                }
+            },
+            "new_account_lincoln": {
+                "data": {
+                    "password": "The Lincoln Way™-passord",
+                    "username": "The Lincoln Way™-brukernavn (e-post)",
+                    "region": "The Lincoln Way™-region"
+                },
+                "data_description": {
+                    "username": "Hvis du bruker mobilnummer i stedet for e-post, oppgi nummeret (uten innledende 0) og inkluder + samt landskode (f.eks. +99123456789)",
+                    "region": "Regionen du velger må stemme overens med regionen du har registrert The Lincoln Way™-kontoen din i. Flere detaljer finner du på GitHub"
+                }
+            },
+            "vehicle": {
+                "title": "Velg kjøretøy som skal legges til",
+                "description": "Bare kjøretøy som ikke allerede er lagt til, vises",
+                "data": {
+                    "vin": "VIN"
+                }
+            },
+            "vin": {
+                "title": "Manuell VIN-inntasting",
+                "description": "Skriv inn VIN-nummeret manuelt – ingen kjøretøy ble funnet automatisk.",
+                "data": {
+                    "vin": "VIN-nummer for kjøretøyet"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "pressure_unit": "Trykkenhet",
+                    "update_interval": "Oppdateringsintervall mot Ford-API (sekunder)",
+                    "scan_interval": "Oppdateringsintervall mot Ford-API (sekunder)",
+                    "force_remote_climate_control": "Vis alltid alternativene for fjernklima (❄|☀)",
+                    "log_to_filesystem": "Logg API-svar til HAs lokale filsystem"
+                },
+                "data_description": {
+                    "update_interval": "Minste intervall er 30 sekunder",
+                    "scan_interval": "Minste intervall er 30 sekunder",
+                    "force_remote_climate_control": "Hvis du aktiverer dette, ignoreres innstillingen som er angitt av Ford.",
+                    "log_to_filesystem": "Denne innstillingen bør ikke være aktivert over lengre tid!\rFilene finner du her: './storage/{integration_name}/data_dumps'"
+                },
+                "description": "Innstillinger for integrasjonen"
+            }
+        }
+    },
+    "services": {
+        "refresh_status": {
+            "name": "Oppdater kjøretøyets status",
+            "description": "Ber bilen om de nyeste opplysningene (kan ta opptil 5 min før statusen er oppdatert).",
+            "fields": {
+                "vin": {
+                    "name": "VIN",
+                    "description": "Oppgi et VIN-nummer for å bare oppdatere det aktuelle kjøretøyet (uten VIN oppdateres alle tillagte kjøretøy)"
+                }
+            }
+        },
+        "clear_tokens": {
+            "name": "Tøm token-cache",
+            "description": "Tømmer de lagrede tokens (krever re-autentisering etterpå)"
+        },
+        "reload": {
+            "name": "Last inn på nytt",
+            "description": "Laster FordPass-integrasjonen inn på nytt"
+        },
+        "poll_api": {
+            "name": "Spør API",
+            "description": "Spør API-et manuelt etter en dataoppdatering (Advarsel: gjør du det for ofte, kan du bli midlertidig blokkert)"
+        },
+        "delete_message": {
+            "name": "Slett FordPass-melding",
+            "description": "Sletter en melding fra meldingslisten. Oppgi en meldings-ID for å slette en bestemt melding.",
+            "fields": {
+                "msgid": {
+                    "name": "Meldings-ID",
+                    "description": "Oppgi en gyldig meldings-ID for å slette en bestemt melding"
+                }
+            }
+        },
+        "update_departure_schedule": {
+            "name": "Oppdater avgangsplan",
+            "description": "Sett et avgangstidspunkt og en forklimatiseringstemperatur for valgte ukedager.",
+            "fields": {
+                "hour": {
+                    "name": "Time",
+                    "description": "Avgangstime (0-23)"
+                },
+                "minute": {
+                    "name": "Minutt",
+                    "description": "Avgangsminutt – i intervaller på 5 min (0-55)"
+                },
+                "precondition_temperature": {
+                    "name": "Forklimatiseringstemperatur"
+                },
+                "schedule_days": {
+                    "name": "Dager",
+                    "description": "Velg én eller flere ukedager"
+                }
+            }
+        },
+        "delete_departure_schedule_by_days": {
+            "name": "Slett avgangsplaner etter dager",
+            "description": "Sletter den første avgangsplanen for de valgte ukedagene.",
+            "fields": {
+                "schedule_days": {
+                    "name": "Dager",
+                    "description": "Velg én eller flere ukedager"
+                }
+            }
+        },
+        "delete_departure_schedule_by_ids": {
+            "name": "Slett avgangsplaner etter ID",
+            "description": "Sletter avgangsplaner basert på deres scheduleID. (se attributtet 'schedule' på sensoren 'Neste planlagte avgang')",
+            "fields": {
+                "schedule_ids": {
+                    "name": "Schedule-IDer",
+                    "description": "Oppgi én eller flere scheduleIDer som liste (f.eks. [1,2,3]) eller komma-separert streng (f.eks. 1,2,3)"
+                }
+            }
+        }
+    },
+    "entity": {
+        "button": {
+            "update_data":          {"name": "Lokal synkronisering"},
+            "request_refresh":      {"name": "Fjernsynkronisering"},
+            "doorlock":             {"name": "Lås"},
+            "doorunlock":           {"name": "Lås opp"},
+            "evstart":              {"name": "Start EV-lading"},
+            "evcancel":             {"name": "Gjenoppta EV-lading"},
+            "evpause":              {"name": "Pause EV-lading"},
+            "hafshort":             {"name": "Horn & blink [1 sek.]"},
+            "hafdefault":           {"name": "Horn & blink [3 sek.]"},
+            "haflong":              {"name": "Horn & blink [5 sek.]"},
+            "extendremotestart":    {"name": "RC (❄|☀): Forleng tid"},
+            "msgdeleteall":         {"name": "Meldinger: Slett alle"},
+            "msgdeletelast":        {"name": "Meldinger: Slett siste"},
+            "trailerlightcheckon":  {"name": "Test av tilhengerlys: PÅ"},
+            "trailerlightcheckoff": {"name": "Test av tilhengerlys: AV"}
+        },
+        "device_tracker":   {"tracker": {"name": "Kjøretøyssporer"}},
+        "lock":             {"doorlock":{"name": "Dører"}},
+        "switch": {
+            "ignition":                 {"name": "RC (❄|☀): Start [Fjernkontroll]"},
+            "elvehcharge":              {"name": "EV-lading (pause)"},
+            "guardmode":                {"name": "Vaktmodus"},
+            "autosoftwareupdates":      {"name": "Automatiske programvareoppdateringer"},
+            "rccdefrostrear":           {"name": "RC (❄|☀): Bakrutevarme [Fjernkontroll]"},
+            "rccdefrostfront":          {"name": "RC (❄|☀): Frontrutevarme [Fjernkontroll]"},
+            "rccsteeringwheel":         {"name": "RC (❄|☀): Rattvarme [Fjernkontroll]"},
+            "departuretimes":           {"name": "Avgangstider"}
+        },
+        "number": {
+            "rcctemperature":       {"name": "RC (❄|☀): Klimatemperatur [Fjernkontroll]"},
+            "elvehtargetcharge":    {"name": "Mål-ladenivå"},
+            "globaltargetsoc":      {"name": "Generelt: Mål-ladenivå"},
+            "globalaccurrentlimit": {"name": "Strømgrense (AC)"},
+            "globaldcpowerlimit":   {"name": "Effektgrense (DC)"}
+        },
+        "sensor": {
+            "odometer":                 {"name": "Kilometerstand"},
+            "fuel":                     {"name": "Drivstoff"},
+            "battery":                  {"name": "Batteri (12V)"},
+            "oil":                      {"name": "Oljelevetid"},
+            "tirepressure":             {"name": "Dekktrykk"},
+            "gps":                      {"name": "GPS JSON"},
+            "alarm":                    {"name": "Alarmstatus"},
+            "ignitionstatus":           {"name": "Status: tenning"},
+            "doorstatus":               {"name": "Status: dører"},
+            "windowposition":           {"name": "Vindusstatus"},
+            "lastrefresh":              {"name": "Sist oppdatert"},
+            "elveh":                    {"name": "EV"},
+            "elvehplug":                {"name": "Ladekontakt"},
+            "elvehcharging":            {"name": "EV-ladestatus"},
+            "elvehchargingpower":       {"name": "EV-ladeeffekt"},
+            "speed":                    {"name": "Hastighet"},
+            "enginespeed":              {"name": "Turtall"},
+            "gearleverposition":        {"name": "Girposisjon"},
+            "indicators":               {"name": "Varsellamper"},
+            "coolanttemp":              {"name": "Temperatur: kjølevæske"},
+            "outsidetemp":              {"name": "Temperatur: utendørs"},
+            "engineoiltemp":            {"name": "Temperatur: motorolje"},
+            "deepsleep":                {"name": "Dvalemodus"},
+            "firmwareupginprogress":    {"name": "Programvareoppdatering pågår"},
+            "remotestartstatus":        {"name": "RC (❄|☀): Status fjernstart"},
+            "zonelighting":             {"name": "Sonebelysning"},
+            "messages":                 {"name": "Meldinger"},
+            "dieselsystemstatus":       {"name": "Status: dieselsystem"},
+            "exhaustfluidlevel":        {"name": "AdBlue-nivå"},
+            "events":                   {"name": "Hendelser"},
+            "metrics":                  {"name": "Målinger"},
+            "states":                   {"name": "Tilstander"},
+            "vehicles":                 {"name": "Kjøretøy"},
+
+            "soc":                      {"name": "Batterinivå (EV)"},
+            "evccstatus":               {"name": "EVCC-statuskode"},
+            "seatbelt":                 {"name": "Sikkerhetsbeltestatus"},
+            "deviceconnectivity":       {"name": "Tilkobling"},
+
+            "yawrate":                  {"name": "Girhastighet"},
+            "acceleration":             {"name": "Akselerasjon"},
+            "brakepedalstatus":         {"name": "Status: bremsepedal"},
+            "braketorque":              {"name": "Bremsemoment"},
+            "acceleratorpedalposition": {"name": "Gasspedal-posisjon"},
+            "parkingbrakestatus":       {"name": "Status: håndbrems"},
+            "torqueattransmission":     {"name": "Dreiemoment ved girkasse"},
+            "wheeltorquestatus":        {"name": "Status: hjulmoment"},
+            "cabintemperature":         {"name": "Kupétemperatur"},
+            "lastenergyconsumed":       {"name": "EV-energiforbruk (siste tur)"},
+            "energytransferlogentry":   {"name": "EV-siste lading"},
+            "remotestartcountdown":     {"name": "RC (❄|☀): Gjenstående tid"},
+            "doorlock":                 {"name": "Status: låser"},
+
+            "departureschedules":       {"name": "Neste planlagte avgang"}
+        },
+        "select": {
+            "zonelighting": {
+                "name": "Sonebelysning",
+                "state": {
+                    "0": "PÅ",
+                    "1": "Foran",
+                    "2": "Bak",
+                    "3": "Førerside",
+                    "4": "Passasjerside",
+                    "off": "AV"
+                }
+            },
+            "rcctemperature": {
+              "name": "RC (❄|☀): Temperatur [Fjernkontroll]",
+              "state": {"lo": "LAV",
+                        "16": "16,0°C", "16_5": "16,5°C", "17": "17,0°C", "17_5": "17,5°C", "18": "18,0°C", "18_5": "18,5°C", "19": "19,0°C", "19_5": "19,5°C", "20": "20,0°C", "20_5": "20,5°C",
+                        "21": "21,0°C", "21_5": "21,5°C", "22": "22,0°C", "22_5": "22,5°C", "23": "23,0°C", "23_5": "23,5°C", "24": "24,0°C", "24_5": "24,5°C", "25": "25,0°C", "25_5": "25,5°C",
+                        "26": "26,0°C", "26_5": "26,5°C", "27": "27,0°C", "27_5": "27,5°C", "28": "28,0°C", "28_5": "28,5°C", "29": "29,0°C", "29_5": "29,5°C", "30": "30,0°C",
+                        "hi": "HØY"}
+            },
+            "rcctemperaturefahrenheit": {
+                "name": "RC (❄|☀): Temperatur [Fjernkontroll]",
+                "state": {"lo": "LAV",
+                          "16": "60.8°F", "16_5": "61.7°F", "17": "62.6°F", "17_5": "63.5°F", "18": "64.4°F", "18_5": "65.3°F", "19": "66.2°F", "19_5": "67.1°F", "20": "68.0°F", "20_5": "68.9°F",
+                          "21": "69.8°F", "21_5": "70.7°F", "22": "71.6°F", "22_5": "72.5°F", "23": "73.4°F", "23_5": "74.3°F", "24": "75.2°F", "24_5": "76.1°F", "25": "77.0°F", "25_5": "77.9°F",
+                          "26": "78.8°F", "26_5": "79.7°F", "27": "80.6°F", "27_5": "81.5°F", "28": "82.4°F", "28_5": "83.3°F", "29": "84.2°F", "29_5": "85.1°F", "30": "86.0°F",
+                          "hi": "HØY"}
+            },
+            "rccseatrearleft": {
+                "name": "RC (❄|☀): Sete bak venstre [Fjernkontroll]",
+                "state": { "off": "Av", "cooled1": "Kjøling I", "cooled2": "Kjøling II", "cooled3": "Kjøling III", "heated1": "Varme I", "heated2": "Varme II", "heated3": "Varme III"}
+            },
+            "rccseatrearright": {
+                "name": "RC (❄|☀): Sete bak høyre [Fjernkontroll]",
+                "state": { "off": "Av", "cooled1": "Kjøling I", "cooled2": "Kjøling II", "cooled3": "Kjøling III", "heated1": "Varme I", "heated2": "Varme II", "heated3": "Varme III"}
+            },
+            "rccseatfrontleft": {
+                "name": "RC (❄|☀): Sete foran venstre [Fjernkontroll]",
+                "state": { "off": "Av", "cooled1": "Kjøling I", "cooled2": "Kjøling II", "cooled3": "Kjøling III", "heated1": "Varme I", "heated2": "Varme II", "heated3": "Varme III"}
+            },
+            "rccseatfrontright": {
+                "name": "RC (❄|☀): Sete foran høyre [Fjernkontroll]",
+                "state": { "off": "Av", "cooled1": "Kjøling I", "cooled2": "Kjøling II", "cooled3": "Kjøling III", "heated1": "Varme I", "heated2": "Varme II", "heated3": "Varme III"}
+            },
+            "elvehtargetcharge": {
+                "name": "Mål-ladenivå",
+                "state": { "50": "50%", "60": "60%", "70": "70%", "80": "80%", "85": "85%", "90": "90%", "95": "95%", "100": "100%"}
+            },
+            "elvehtargetchargealt1": {
+                "name": "Mål-ladenivå [alternativ plassering 1]",
+                "state": { "50": "50%", "60": "60%", "70": "70%", "80": "80%", "85": "85%", "90": "90%", "95": "95%", "100": "100%"}
+            },
+            "elvehtargetchargealt2": {
+                "name": "Mål-ladenivå [alternativ plassering 2]",
+                "state": { "50": "50%", "60": "60%", "70": "70%", "80": "80%", "85": "85%", "90": "90%", "95": "95%", "100": "100%"}
+            },
+            "globaltargetsoc": {
+                "name": "Generelt: Mål-ladenivå",
+                "state": { "50": "50%", "60": "60%", "70": "70%", "80": "80%", "85": "85%", "90": "90%", "95": "95%", "100": "100%"}
+            }
+        }
+    }
+}

--- a/custom_components/fordpass/translations/sv.json
+++ b/custom_components/fordpass/translations/sv.json
@@ -1,0 +1,424 @@
+{
+    "selector": {
+        "region": {
+            "options": {
+                "aaa": "------ FORD-fordon ------",
+                "deu": "Tyskland",
+                "dnk": "Danmark",
+                "fra": "Frankrike",
+                "nld": "Nederländerna",
+                "ita": "Italien",
+                "esp": "Spanien",
+                "nor": "Norge",
+                "pol": "Polen",
+                "prt": "Portugal",
+                "gbr": "Storbritannien och Nordirland",
+                "aus": "Australien [kräver ett 'ford.com.au/ford.co.nz'-konto]",
+                "nzl": "Nya Zeeland [kräver ett 'ford.co.nz/ford.com.au'-konto]",
+                "zaf": "Sydafrika [kräver ett 'ford.co.za'-konto]",
+                "can": "Kanada",
+                "mex": "Mexiko",
+                "usa": "USA",
+                "bra": "Brasilien [kräver ett 'ford.com.br/ford.com.ar'-konto]",
+                "arg": "Argentina [kräver ett 'ford.com.ar/ford.com.br'-konto]",
+                "rest_of_europe": "Övriga europeiska länder",
+                "rest_of_world": "Resten av världen",
+                "zzz": "------ LINCOLN-fordon ------",
+                "lincoln_usa": "USA"
+            }
+        },
+        "setup_type": {
+            "options": {
+                "new_account": "Lägg till ett nytt FordPass™/The Lincoln Way™-konto eller konfigurera en ny region",
+                "add_vehicle": "Lägg till ett fordon från ett befintligt FordPass™/The Lincoln Way™-konto/region"
+            }
+        },
+        "brand": {
+            "options": {
+                "ford": "Ford-fordon – FordPass™-app",
+                "lincoln": "Lincoln-fordon – The Lincoln Way™-app"
+            }
+        },
+        "precondition_temperature": {
+            "options": {
+                "low": "Sval",
+                "medium": "Mellan",
+                "high": "Varm",
+                "off": "Av"
+            }
+        },
+        "schedule_days": {
+            "options": {
+                "monday": "01 Måndag",
+                "tuesday": "02 Tisdag",
+                "wednesday": "03 Onsdag",
+                "thursday": "04 Torsdag",
+                "friday": "05 Fredag",
+                "saturday": "06 Lördag",
+                "sunday": "07 Söndag"
+            }
+        }
+    },
+    "config": {
+        "abort": {
+            "already_configured": "Kontot är redan konfigurerat",
+            "no_vehicles": "Det finns inga fordon på kontot, eller alla är redan tillagda",
+            "reauth_successful": "Återautentiseringen lyckades",
+            "reconfigure_successful": "Omkonfigurationen lyckades",
+            "reauth_reload_failed": "Återautentiseringen lyckades\n\nMen integrationen kunde inte laddas om. Starta om Home Assistant för att slutföra återautentiseringen, eller kontrollera loggen för mer information",
+            "reauth_unsuccessful": "Återautentiseringen MISSLYCKADES\n\nKontrollera token och försök igen",
+            "reauth_not_possible": "Ingen giltig region hittades\n\nDu måste tyvärr konfigurera om integrationen från början",
+            "no_filesystem_access": "Den här integrationen behöver åtkomst till det lokala filsystemet i din Home Assistant-installation för att kunna spara en nyckel till ditt FordPass™/The Lincoln Way™-konto.\n\nFör detta skapas en undermapp i mappen '.storage/'. Det går inte just nu – ett internt test misslyckades. Du hittar detaljer i din Home Assistant-logg.\n\nKontrollera att Home Assistant körs som rätt användare med skrivrättigheter till det lokala filsystemet.\n\nKör du Home Assistant i en Docker-container, se till att containern körs med rätt användare och har åtkomst till filsystemet.\n\nKontrollera installationen och starta om konfigurationen av integrationen när åtkomst till filsystemet är möjlig.",
+            "no_brand": "Inget bilmärke (Ford eller Lincoln) kunde identifieras",
+            "oauth_error_final": "## Hämtningen av det slutgiltiga OAuth-tokenet misslyckades\nNågot gick fel när det slutgiltiga åtkomsttokenet skulle hämtas från Ford. Är du säker på att uppgifterna du angett som `client-id` och `secret` är korrekta?\nKontrollera även loggen i din Home Assistant för fler felmeddelanden, som kan hjälpa dig hitta orsaken.\n\n#### Möjlig orsak:\n{error_info}"
+        },
+        "error": {
+            "cannot_connect": "Kunde inte ansluta",
+            "invalid_auth": "Felaktiga inloggningsuppgifter",
+            "invalid_vin": "VIN-numret hittades inte på kontot",
+            "invalid_mobile": "Om du använder den sydafrikanska regionen måste mobilnumret anges som användarnamn",
+            "invalid_token": "Tokenet är ogiltigt. Kontrollera att du har kopierat rätt token från Header-Location – det ska börja med fordapp:// (eller lincolnapp://)",
+            "unknown": "Oväntat fel"
+        },
+        "step": {
+            "user": {
+                "title": "Lägg till nytt FordPass™/The Lincoln Way™-konto eller fordon",
+                "description": "Eftersom du redan har konfigurerat minst ett FordPass™/The Lincoln Way™-konto måste du först välja om du vill lägga till ytterligare ett fordon eller ett nytt konto (eller ny region).\n-- --\n### Viktig information om stöd för flera fordon\n\nOm du har __flera__ fordon registrerade på ditt FordPass™/The Lincoln Way™-konto, måste du i själva FordPass™/The Lincoln Way™-appen först välja det fordon du vill använda innan du kan se data eller styra funktioner. __Samma begränsning__ gäller för den här Home Assistant-integrationen.\n\nOrsaken är att FordPass™-appen och denna integration använder en websocket-anslutning till Fords backend, och den är bunden till ett fordon i taget.\n\nMer information finns här: {repo}?tab=readme-ov-file#multi-vehicle-support",
+                "data": {
+                    "setup_type": "Vad vill du göra?"
+                },
+                "data_description": {
+                    "setup_type": "Om du lägger till ett andra fordon med samma konto får bara ett av dem vara aktivt i HA åt gången – annars skriver de över varandras åtkomsttokens"
+                }
+            },
+            "user_connect": {
+                "title": "Lägg till ett nytt Ford-fordon",
+                "description": "## Välkommen till FordConnect Query-integrationen\nDet här är ett alternativ till [FordPass-integrationen]({repo}) och använder FordConnect Query-API:et. Det API:et ger __endast läsåtkomst__ till dina fordonsdata.\n### Krav\n- Bilen måste ha det senaste inbyggda modemet och vara registrerad/godkänd i FordPass™-appen\n- Ett par API-uppgifter som tidigare registrerats hos Fords utvecklarportal i EU/UK/NA.\n\nMer information finns i [_Application Registration Guide_, som även innehåller en steg-för-steg-anvisning]({repo}/blob/main/docs/REGISTER_APPLICATION.md) för att registrera ett program på Fords EU-utvecklarportal.\n### Behöver du mer hjälp?\nResten av installationen beskrivs i [Integration Setup Guide]({repo}/blob/main/docs/CONFIGURE_INTEGRATION.md)\n### Slutligen\nOm du tycker att integrationen är användbar, överväg att stötta mig som GitHub-projektsponsor (eller på något av de andra sätt som beskrivs [här i min profil@GitHub]({github})) – stort tack till alla som redan gör det – ni är fantastiska!",
+                "data": {
+                    "config_title": "Välj ett namn för konfigurationen"
+                }
+            },
+            "select_account": {
+                "title": "Välj ditt FordPass™/The Lincoln Way™-konto",
+                "description": "Välj det FordPass™/The Lincoln Way™-konto som du vill lägga till ytterligare ett fordon från.",
+                "data": {
+                    "account": "FordPass™/The Lincoln Way™-konto"
+                },
+                "data_description": {
+                    "account": "Om du lägger till ett andra fordon med samma konto får bara ett av dem vara aktivt i HA åt gången – annars skriver de över varandras åtkomsttokens"
+                }
+            },
+            "token": {
+                "title": "Konfigurera token",
+                "description": "Konfigurationen av token kräver att du öppnar ytterligare ett webbläsarfönster (med utvecklarverktygen aktiverade – F12) för att fånga det slutgiltiga åtkomsttokenet.\r\rDet är ett ovanligt förfarande för en Home Assistant-integration. Mer detaljer finns i [installationsguiden]({repo}/blob/main/doc/OBTAINING_TOKEN.md)\r\rFölj dessa steg:\r1. Kopiera URL:en nedan eller klicka på följande länk (måste öppnas i en ny flik/fönster): [Starta auktoriseringsprocessen]({url})\r2. Öppna en webbläsare (med utvecklarverktygen aktiverade) och klistra in URL:en i det andra webbläsarfönstret\r3. Ange dina FordPass™/The Lincoln Way™-uppgifter (igen) och tryck på inloggningsknappen\r4. Håll utkik på fliken Network tills du ser begäran `?code=`\r5. Kopiera hela `Request-URL` från den begäran i webbläsarens utvecklarverktyg och klistra in i token-fältet nedan\r6. Klicka OK för att fortsätta",
+                "data": {
+                    "url": "URL: kopiera in denna i din webbläsare",
+                    "tokenstr": "Token Request-URL: klistra in hela `Request-URL` när inloggningen är klar i webbläsaren"
+                }
+            },
+            "reauth_confirm": {
+                "title": "Återautentisering krävs",
+                "description": "Ditt tidigare token är ogiltigt – så du måste skapa ett nytt för kontot {username}:\r\rDetaljer finns i [installationsguiden]({repo}/blob/main/doc/OBTAINING_TOKEN.md)\r\rFölj dessa steg:\r1. Kopiera URL:en nedan eller klicka på följande länk (måste öppnas i en ny flik/fönster): [Starta auktoriseringsprocessen]({url})\r2. Öppna en webbläsare (med utvecklarverktygen aktiverade) och klistra in URL:en i det andra webbläsarfönstret\r3. Ange dina FordPass™/The Lincoln Way™-uppgifter (igen) och tryck på inloggningsknappen (låt dig inte luras av att spinnern fortsätter snurra – det är 'normalt')\r4. Håll utkik på fliken Network tills du ser begäran `?code=`\r5. Kopiera hela `Request-URL` från den begäran i webbläsarens utvecklarverktyg och klistra in i token-fältet nedan\r6. Klicka OK för att fortsätta",
+                "data": {
+                    "url": "URL: kopiera in denna i din webbläsare",
+                    "tokenstr": "Token Request-URL: klistra in hela `Request-URL` när inloggningen är klar i webbläsaren"
+                }
+            },
+            "reauth_confirm_connect": {
+                "title": "Återautentisering krävs",
+                "description": "Ditt tidigare token är ogiltigt – så du måste skapa ett nytt för kontot {username}"
+            },
+            "brand": {
+                "data": {
+                    "brand": "Välj ditt bilmärke"
+                }
+            },
+            "new_account_ford": {
+                "data": {
+                    "password": "FordPass™-lösenord",
+                    "username": "FordPass™-användarnamn (e-post)",
+                    "region": "FordPass™-region"
+                },
+                "data_description": {
+                    "username": "Om du använder mobilnummer i stället för e-post, ange numret (utan inledande 0) och inkludera + samt landskoden (t.ex. +99123456789)",
+                    "region": "Den region du väljer måste matcha den region där du har registrerat ditt FordPass™-konto. Mer detaljer finns på GitHub"
+                }
+            },
+            "new_account_lincoln": {
+                "data": {
+                    "password": "The Lincoln Way™-lösenord",
+                    "username": "The Lincoln Way™-användarnamn (e-post)",
+                    "region": "The Lincoln Way™-region"
+                },
+                "data_description": {
+                    "username": "Om du använder mobilnummer i stället för e-post, ange numret (utan inledande 0) och inkludera + samt landskoden (t.ex. +99123456789)",
+                    "region": "Den region du väljer måste matcha den region där du har registrerat ditt The Lincoln Way™-konto. Mer detaljer finns på GitHub"
+                }
+            },
+            "vehicle": {
+                "title": "Välj fordon att lägga till",
+                "description": "Endast fordon som inte redan är tillagda visas",
+                "data": {
+                    "vin": "VIN"
+                }
+            },
+            "vin": {
+                "title": "Manuell VIN-inmatning",
+                "description": "Ange ditt VIN-nummer manuellt eftersom inga fordon kunde hittas automatiskt.",
+                "data": {
+                    "vin": "VIN-nummer för fordonet"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "pressure_unit": "Tryckenhet",
+                    "update_interval": "Uppdateringsintervall mot Ford-API (sekunder)",
+                    "scan_interval": "Uppdateringsintervall mot Ford-API (sekunder)",
+                    "force_remote_climate_control": "Visa alltid alternativen för fjärrklimat (❄|☀)",
+                    "log_to_filesystem": "Logga API-svar till HA:s lokala filsystem"
+                },
+                "data_description": {
+                    "update_interval": "Minsta intervall är 30 sekunder",
+                    "scan_interval": "Minsta intervall är 30 sekunder",
+                    "force_remote_climate_control": "Om du aktiverar detta ignoreras inställningen som anges av Ford.",
+                    "log_to_filesystem": "Den här inställningen bör inte vara aktiverad under en längre tid!\rFilerna finns här: './storage/{integration_name}/data_dumps'"
+                },
+                "description": "Inställningar för integrationen"
+            }
+        }
+    },
+    "services": {
+        "refresh_status": {
+            "name": "Uppdatera fordonsstatus",
+            "description": "Begär de senaste uppgifterna från bilen (kan ta upp till 5 min innan statusen är uppdaterad).",
+            "fields": {
+                "vin": {
+                    "name": "VIN",
+                    "description": "Ange ett VIN-nummer för att bara uppdatera det angivna fordonet (utan VIN uppdateras alla tillagda fordon)"
+                }
+            }
+        },
+        "clear_tokens": {
+            "name": "Rensa token-cache",
+            "description": "Rensar de sparade tokens (kräver återautentisering efteråt)"
+        },
+        "reload": {
+            "name": "Ladda om",
+            "description": "Laddar om FordPass-integrationen"
+        },
+        "poll_api": {
+            "name": "Anropa API",
+            "description": "Anropar API:et manuellt för en datauppdatering (Varning: gör du det för ofta kan du bli tillfälligt blockerad)"
+        },
+        "delete_message": {
+            "name": "Radera FordPass-meddelande",
+            "description": "Raderar ett meddelande från meddelandelistan. Ange ett meddelande-ID för att radera ett specifikt meddelande.",
+            "fields": {
+                "msgid": {
+                    "name": "Meddelande-ID",
+                    "description": "Ange ett giltigt meddelande-ID för att radera ett specifikt meddelande"
+                }
+            }
+        },
+        "update_departure_schedule": {
+            "name": "Uppdatera avgångsschema",
+            "description": "Ställ in avgångstid och förkonditioneringstemperatur för utvalda dagar.",
+            "fields": {
+                "hour": {
+                    "name": "Timme",
+                    "description": "Avgångstimme (0-23)"
+                },
+                "minute": {
+                    "name": "Minut",
+                    "description": "Avgångsminut – i intervall om 5 min (0-55)"
+                },
+                "precondition_temperature": {
+                    "name": "Förkonditioneringstemperatur"
+                },
+                "schedule_days": {
+                    "name": "Dagar",
+                    "description": "Välj en eller flera veckodagar"
+                }
+            }
+        },
+        "delete_departure_schedule_by_days": {
+            "name": "Radera avgångsscheman efter dagar",
+            "description": "Raderar det första avgångsschemat för de valda veckodagarna.",
+            "fields": {
+                "schedule_days": {
+                    "name": "Dagar",
+                    "description": "Välj en eller flera veckodagar"
+                }
+            }
+        },
+        "delete_departure_schedule_by_ids": {
+            "name": "Radera avgångsscheman efter ID",
+            "description": "Raderar avgångsscheman utifrån deras scheduleID. (se attributet 'schedule' på sensorn 'Nästa schemalagda avgång')",
+            "fields": {
+                "schedule_ids": {
+                    "name": "Schedule-ID:n",
+                    "description": "Ange ett eller flera scheduleID:n som lista (t.ex. [1,2,3]) eller kommaseparerad sträng (t.ex. 1,2,3)"
+                }
+            }
+        }
+    },
+    "entity": {
+        "button": {
+            "update_data":          {"name": "Lokal synkronisering"},
+            "request_refresh":      {"name": "Fjärrsynkronisering"},
+            "doorlock":             {"name": "Lås"},
+            "doorunlock":           {"name": "Lås upp"},
+            "evstart":              {"name": "Starta EV-laddning"},
+            "evcancel":             {"name": "Återuppta EV-laddning"},
+            "evpause":              {"name": "Pausa EV-laddning"},
+            "hafshort":             {"name": "Tut & blink [1 sek.]"},
+            "hafdefault":           {"name": "Tut & blink [3 sek.]"},
+            "haflong":              {"name": "Tut & blink [5 sek.]"},
+            "extendremotestart":    {"name": "RC (❄|☀): Förläng tid"},
+            "msgdeleteall":         {"name": "Meddelanden: Radera alla"},
+            "msgdeletelast":        {"name": "Meddelanden: Radera senaste"},
+            "trailerlightcheckon":  {"name": "Test av släpljus: PÅ"},
+            "trailerlightcheckoff": {"name": "Test av släpljus: AV"}
+        },
+        "device_tracker":   {"tracker": {"name": "Fordonsspårare"}},
+        "lock":             {"doorlock":{"name": "Dörrar"}},
+        "switch": {
+            "ignition":                 {"name": "RC (❄|☀): Start [Fjärrkontroll]"},
+            "elvehcharge":              {"name": "EV-laddning (paus)"},
+            "guardmode":                {"name": "Vakttillstånd"},
+            "autosoftwareupdates":      {"name": "Automatiska programuppdateringar"},
+            "rccdefrostrear":           {"name": "RC (❄|☀): Bakrutevärme [Fjärrkontroll]"},
+            "rccdefrostfront":          {"name": "RC (❄|☀): Vindrutevärme [Fjärrkontroll]"},
+            "rccsteeringwheel":         {"name": "RC (❄|☀): Rattvärme [Fjärrkontroll]"},
+            "departuretimes":           {"name": "Avgångstider"}
+        },
+        "number": {
+            "rcctemperature":       {"name": "RC (❄|☀): Klimattemperatur [Fjärrkontroll]"},
+            "elvehtargetcharge":    {"name": "Mål-laddningsnivå"},
+            "globaltargetsoc":      {"name": "Allmän: Mål-laddningsnivå"},
+            "globalaccurrentlimit": {"name": "Strömgräns (AC)"},
+            "globaldcpowerlimit":   {"name": "Effektgräns (DC)"}
+        },
+        "sensor": {
+            "odometer":                 {"name": "Mätarställning"},
+            "fuel":                     {"name": "Bränsle"},
+            "battery":                  {"name": "Batteri (12V)"},
+            "oil":                      {"name": "Oljelivslängd"},
+            "tirepressure":             {"name": "Däcktryck"},
+            "gps":                      {"name": "GPS JSON"},
+            "alarm":                    {"name": "Larmstatus"},
+            "ignitionstatus":           {"name": "Status: tändning"},
+            "doorstatus":               {"name": "Status: dörrar"},
+            "windowposition":           {"name": "Fönsterstatus"},
+            "lastrefresh":              {"name": "Senast uppdaterad"},
+            "elveh":                    {"name": "EV"},
+            "elvehplug":                {"name": "Laddkontakt"},
+            "elvehcharging":            {"name": "EV-laddstatus"},
+            "elvehchargingpower":       {"name": "EV-laddeffekt"},
+            "speed":                    {"name": "Hastighet"},
+            "enginespeed":              {"name": "Varvtal"},
+            "gearleverposition":        {"name": "Växelläge"},
+            "indicators":               {"name": "Varningslampor"},
+            "coolanttemp":              {"name": "Temperatur: kylvätska"},
+            "outsidetemp":              {"name": "Temperatur: utomhus"},
+            "engineoiltemp":            {"name": "Temperatur: motorolja"},
+            "deepsleep":                {"name": "Vilolage"},
+            "firmwareupginprogress":    {"name": "Programuppdatering pågår"},
+            "remotestartstatus":        {"name": "RC (❄|☀): Status fjärrstart"},
+            "zonelighting":             {"name": "Zonbelysning"},
+            "messages":                 {"name": "Meddelanden"},
+            "dieselsystemstatus":       {"name": "Status: dieselsystem"},
+            "exhaustfluidlevel":        {"name": "AdBlue-nivå"},
+            "events":                   {"name": "Händelser"},
+            "metrics":                  {"name": "Mätvärden"},
+            "states":                   {"name": "Tillstånd"},
+            "vehicles":                 {"name": "Fordon"},
+
+            "soc":                      {"name": "Batterinivå (EV)"},
+            "evccstatus":               {"name": "EVCC-statuskod"},
+            "seatbelt":                 {"name": "Säkerhetsbältesstatus"},
+            "deviceconnectivity":       {"name": "Anslutning"},
+
+            "yawrate":                  {"name": "Girhastighet"},
+            "acceleration":             {"name": "Acceleration"},
+            "brakepedalstatus":         {"name": "Status: bromspedal"},
+            "braketorque":              {"name": "Bromsmoment"},
+            "acceleratorpedalposition": {"name": "Gaspedal-läge"},
+            "parkingbrakestatus":       {"name": "Status: handbroms"},
+            "torqueattransmission":     {"name": "Vridmoment vid växellåda"},
+            "wheeltorquestatus":        {"name": "Status: hjulmoment"},
+            "cabintemperature":         {"name": "Kupétemperatur"},
+            "lastenergyconsumed":       {"name": "EV-energiförbrukning (senaste resa)"},
+            "energytransferlogentry":   {"name": "EV-senaste laddning"},
+            "remotestartcountdown":     {"name": "RC (❄|☀): Återstående tid"},
+            "doorlock":                 {"name": "Status: lås"},
+
+            "departureschedules":       {"name": "Nästa schemalagda avgång"}
+        },
+        "select": {
+            "zonelighting": {
+                "name": "Zonbelysning",
+                "state": {
+                    "0": "PÅ",
+                    "1": "Fram",
+                    "2": "Bak",
+                    "3": "Förarsidan",
+                    "4": "Passagerarsidan",
+                    "off": "AV"
+                }
+            },
+            "rcctemperature": {
+              "name": "RC (❄|☀): Temperatur [Fjärrkontroll]",
+              "state": {"lo": "LÅG",
+                        "16": "16,0°C", "16_5": "16,5°C", "17": "17,0°C", "17_5": "17,5°C", "18": "18,0°C", "18_5": "18,5°C", "19": "19,0°C", "19_5": "19,5°C", "20": "20,0°C", "20_5": "20,5°C",
+                        "21": "21,0°C", "21_5": "21,5°C", "22": "22,0°C", "22_5": "22,5°C", "23": "23,0°C", "23_5": "23,5°C", "24": "24,0°C", "24_5": "24,5°C", "25": "25,0°C", "25_5": "25,5°C",
+                        "26": "26,0°C", "26_5": "26,5°C", "27": "27,0°C", "27_5": "27,5°C", "28": "28,0°C", "28_5": "28,5°C", "29": "29,0°C", "29_5": "29,5°C", "30": "30,0°C",
+                        "hi": "HÖG"}
+            },
+            "rcctemperaturefahrenheit": {
+                "name": "RC (❄|☀): Temperatur [Fjärrkontroll]",
+                "state": {"lo": "LÅG",
+                          "16": "60.8°F", "16_5": "61.7°F", "17": "62.6°F", "17_5": "63.5°F", "18": "64.4°F", "18_5": "65.3°F", "19": "66.2°F", "19_5": "67.1°F", "20": "68.0°F", "20_5": "68.9°F",
+                          "21": "69.8°F", "21_5": "70.7°F", "22": "71.6°F", "22_5": "72.5°F", "23": "73.4°F", "23_5": "74.3°F", "24": "75.2°F", "24_5": "76.1°F", "25": "77.0°F", "25_5": "77.9°F",
+                          "26": "78.8°F", "26_5": "79.7°F", "27": "80.6°F", "27_5": "81.5°F", "28": "82.4°F", "28_5": "83.3°F", "29": "84.2°F", "29_5": "85.1°F", "30": "86.0°F",
+                          "hi": "HÖG"}
+            },
+            "rccseatrearleft": {
+                "name": "RC (❄|☀): Säte bak vänster [Fjärrkontroll]",
+                "state": { "off": "Av", "cooled1": "Kylning I", "cooled2": "Kylning II", "cooled3": "Kylning III", "heated1": "Värme I", "heated2": "Värme II", "heated3": "Värme III"}
+            },
+            "rccseatrearright": {
+                "name": "RC (❄|☀): Säte bak höger [Fjärrkontroll]",
+                "state": { "off": "Av", "cooled1": "Kylning I", "cooled2": "Kylning II", "cooled3": "Kylning III", "heated1": "Värme I", "heated2": "Värme II", "heated3": "Värme III"}
+            },
+            "rccseatfrontleft": {
+                "name": "RC (❄|☀): Säte fram vänster [Fjärrkontroll]",
+                "state": { "off": "Av", "cooled1": "Kylning I", "cooled2": "Kylning II", "cooled3": "Kylning III", "heated1": "Värme I", "heated2": "Värme II", "heated3": "Värme III"}
+            },
+            "rccseatfrontright": {
+                "name": "RC (❄|☀): Säte fram höger [Fjärrkontroll]",
+                "state": { "off": "Av", "cooled1": "Kylning I", "cooled2": "Kylning II", "cooled3": "Kylning III", "heated1": "Värme I", "heated2": "Värme II", "heated3": "Värme III"}
+            },
+            "elvehtargetcharge": {
+                "name": "Mål-laddningsnivå",
+                "state": { "50": "50%", "60": "60%", "70": "70%", "80": "80%", "85": "85%", "90": "90%", "95": "95%", "100": "100%"}
+            },
+            "elvehtargetchargealt1": {
+                "name": "Mål-laddningsnivå [alternativ plats 1]",
+                "state": { "50": "50%", "60": "60%", "70": "70%", "80": "80%", "85": "85%", "90": "90%", "95": "95%", "100": "100%"}
+            },
+            "elvehtargetchargealt2": {
+                "name": "Mål-laddningsnivå [alternativ plats 2]",
+                "state": { "50": "50%", "60": "60%", "70": "70%", "80": "80%", "85": "85%", "90": "90%", "95": "95%", "100": "100%"}
+            },
+            "globaltargetsoc": {
+                "name": "Allmän: Mål-laddningsnivå",
+                "state": { "50": "50%", "60": "60%", "70": "70%", "80": "80%", "85": "85%", "90": "90%", "95": "95%", "100": "100%"}
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hi marq24,

Thanks for the great integration!

Adds three new Nordic translation files (da.json, sv.json, no.json)
   following the same structure as the existing translations. Each file
   uses natural automotive terminology in the target language rather
   than literal English-to-Nordic translations.