### PR TITLE
fix(config_flow): validate_vin reads .status_code on a parsed JSON dict, so every valid VIN fails setup

### DIFF
--- a/custom_components/fordpass/config_flow.py
+++ b/custom_components/fordpass/config_flow.py
@@ -51,6 +51,7 @@ from .const_shared import (
     DEFAULT_PRESSURE_UNIT,
 )
 from .fordpass_bridge import ConnectedFordPassVehicle
+from .fordpass_handler import ROOT_METRICS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -254,7 +255,17 @@ class FordPassConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
         test = await bridge.req_status()
         _LOGGER.debug(f"GOT SOMETHING BACK? {test}")
-        if test and test.status_code == 200:
+        # req_status() returns the PARSED JSON (a dict) on HTTP 200, or None - it never
+        # returns an object carrying .status_code, so reading that attribute raised
+        # AttributeError for every VALID vin and the config flow reported "unknown".
+        # A 403/not-authorized vehicle returns {ROOT_METRICS: {}}, i.e. a truthy dict with
+        # no metrics, and must still be treated as an invalid vin.
+        if isinstance(test, dict):
+            if test.get(ROOT_METRICS):
+                _LOGGER.debug("200 Code")
+                return True
+            raise InvalidVin
+        if test and getattr(test, "status_code", None) == 200:
             _LOGGER.debug("200 Code")
             return True
         if not test:


### PR DESCRIPTION
## The bug

`validate_vin()` in `config_flow.py` does:

```python
test = await bridge.req_status()
_LOGGER.debug(f"GOT SOMETHING BACK? {test}")
if test and test.status_code == 200:
```

but `ConnectedFordPassVehicle.req_status()` returns **the parsed JSON body** (a `dict`) on HTTP 200, and `None` otherwise. It never returns an object carrying `.status_code`.

So on a **valid** VIN, `test` is a dict, `test.status_code` raises `AttributeError`, the config flow catches it as an unexpected exception, and the user is shown **"Unexpected error"** with nothing in the log to explain it. `_LOGGER.debug("200 Code")` is unreachable.

Setup cannot complete.

## How it is reached

Only accounts that have to type the VIN in by hand hit this. In my case `POST https://api.vehicle.ford.com/api/expdashboard/v1/details/` answers **404**, so `validate_token()` logs `NO VEHICLES FOUND` and the flow falls through to the VIN step - and then always fails there.

Debug log from 2026.8.2, trimmed, in order:

```
config_flow          validate_token(): got Vehicles -> None
config_flow          NO VEHICLES FOUND in info None
config_flow          validate_vin(): {'region': 'usa', 'username': '...', 'vin': '1FT...'}
fordpass_bridge      REQUEST: GET https://api.autonomic.ai/v1/telemetry/sources/fordpass/vehicles/1FT...
config_flow          GOT SOMETHING BACK? {'updateTime': '...', 'vehicleId': '...', 'vin': '1FT...', 'metrics': {...}}
```

That last line is the tell: a `dict`, not a response. The vehicle data is entirely healthy - fuel level, tyre pressures, door and window status, indicators, all present - and the flow throws it away.

Vehicle: 2026 F-150. Home Assistant 2026.8.3, integration 2026.8.2.

## The fix

Test the shape the function actually returns.

⚠ One thing worth keeping: `req_status()` returns `{ROOT_METRICS: {}}` for a **403 / not authorized** vehicle - a truthy dict with no metrics. A bare `if test:` would accept that and let an unauthorized VIN through setup, so the check is on the metrics rather than on truthiness. The original attribute path is left in place for any caller that does hand back a response object.

I've been running this patched on my own instance since finding it; setup completes and the vehicle's entities populate.

Thanks for maintaining this - it is the only thing that gets a Ford into Home Assistant properly.
